### PR TITLE
La contrasenya del phpMyAdmin hauria de ser la passada per paràmetre

### DIFF
--- a/provision/mysql.sh
+++ b/provision/mysql.sh
@@ -22,7 +22,7 @@ rm phpMyAdmin-latest-all-languages.tar.gz &> /dev/null
 
 # Configure phpMyAdmin
 cp phpmyadmin/config.sample.inc.php phpmyadmin/config.inc.php
-sudo sed -i "s/.*\['auth_type'\].*/\$cfg['Servers'][\$i]['auth_type'] = 'config';\n\$cfg['Servers'][\$i]['user'] = 'root';\n\$cfg['Servers'][\$i]['password'] = 'agora';/" phpmyadmin/config.inc.php
+sudo sed -i "s/.*\['auth_type'\].*/\$cfg['Servers'][\$i]['auth_type'] = 'config';\n\$cfg['Servers'][\$i]['user'] = 'root';\n\$cfg['Servers'][\$i]['password'] = '$pass';/" phpmyadmin/config.inc.php
 popd &> /dev/null || exit
 
 sudo service mysql restart


### PR DESCRIPTION
En el codi actual la contrasenya del phpMyAdmin estava "gravada a foc" (agora) en la comanda, en comptes de fer servir la variable $pass.

Imagino que és preferible que es configuri la mateixa contrasenya que s'ha passat per paràmetre com amb el MySQL root password.